### PR TITLE
feat(ad-signal-hijack): scaffold route, page shell, and nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
-import NotFound from "./pages/NotFound";
 import AdSignalHijack from "./pages/AdSignalHijack";
+import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import AdSignalHijack from "./pages/AdSignalHijack";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/ad-signal-hijack" element={<AdSignalHijack />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,20 +1,80 @@
 import { Shield, Target, Map, Bell, TrendingUp, Users, Settings, Zap, Database } from 'lucide-react';
-import { NavLink } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const Navigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const modules = [
-    { name: "Command Center", icon: Shield, path: "/", badge: null, description: "Intelligence dashboard" },
-    { name: "Ad Signal Hijack", icon: Zap, path: "/ad-signal-hijack", badge: "34", description: "Competitor ad tracking" },
-    { name: "Lead Locator", icon: Users, path: "/lead-locator", badge: "156", description: "Prospect identification" },
-    { name: "Dominance Map", icon: Map, path: "/dominance-map", badge: null, description: "Territory analysis" },
-    { name: "Task Generator", icon: Target, path: "/task-generator", badge: null, description: "Action recommendations" },
-    { name: "Change Alerts", icon: Bell, path: "/change-alerts", badge: "3", description: "Real-time monitoring" },
-    { name: "Campaign Manager", icon: TrendingUp, path: "/campaign-manager", badge: null, description: "Campaign automation" },
-    { name: "Competitive CRM", icon: Database, path: "/crm", badge: null, description: "Lead management" },
+    { 
+      name: "Command Center", 
+      icon: Shield, 
+      active: location.pathname === '/', 
+      badge: null,
+      description: "Intelligence dashboard",
+      path: "/"
+    },
+    { 
+      name: "Ad Signal Hijack", 
+      icon: Zap, 
+      active: location.pathname === '/ad-signal-hijack', 
+      badge: "34",
+      description: "Competitor ad tracking",
+      path: "/ad-signal-hijack"
+    },
+    { 
+      name: "Lead Locator", 
+      icon: Users, 
+      active: false, 
+      badge: "156",
+      description: "Prospect identification",
+      path: "/lead-locator"
+    },
+    { 
+      name: "Dominance Map", 
+      icon: Map, 
+      active: false, 
+      badge: null,
+      description: "Territory analysis",
+      path: "/dominance-map"
+    },
+    { 
+      name: "Task Generator", 
+      icon: Target, 
+      active: false, 
+      badge: null,
+      description: "Action recommendations",
+      path: "/task-generator"
+    },
+    { 
+      name: "Change Alerts", 
+      icon: Bell, 
+      active: false, 
+      badge: "3",
+      description: "Real-time monitoring",
+      path: "/change-alerts"
+    },
+    { 
+      name: "Campaign Manager", 
+      icon: TrendingUp, 
+      active: false, 
+      badge: null,
+      description: "Campaign automation",
+      path: "/campaign-manager"
+    },
+    { 
+      name: "Competitive CRM", 
+      icon: Database, 
+      active: false, 
+      badge: null,
+      description: "Lead management",
+      path: "/competitive-crm"
+    }
   ];
 
   return (
     <div className="w-72 h-screen bg-background-secondary border-r border-border flex flex-col">
+      {/* Header */}
       <div className="p-6 border-b border-border">
         <div className="flex items-center gap-3 mb-4">
           <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
@@ -25,6 +85,7 @@ const Navigation = () => {
             <p className="text-xs text-muted-foreground">Intelligence Platform</p>
           </div>
         </div>
+        
         <div className="bg-card border border-border rounded-xl p-3 shadow-sm">
           <div className="flex items-center justify-between text-sm">
             <span className="text-card-foreground/70">Active Targets</span>
@@ -32,36 +93,62 @@ const Navigation = () => {
           </div>
         </div>
       </div>
-
+      
+      {/* Navigation */}
       <div className="flex-1 p-4 space-y-2">
         <div className="mb-4">
-          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">Intelligence Modules</h2>
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            Intelligence Modules
+          </h2>
         </div>
-
+        
         {modules.map((module, index) => (
-          <NavLink key={index} to={module.path} className={({ isActive }) => `w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200 ${isActive ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm' : 'text-foreground hover:bg-accent hover:text-accent-foreground'}`}>
+          <button
+            key={index}
+            onClick={() => navigate(module.path)}
+            className={`w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200 ${
+              module.active 
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm' 
+                : 'text-foreground hover:bg-accent hover:text-accent-foreground'
+            }`}
+          >
             <module.icon className="w-5 h-5 flex-shrink-0" />
             <div className="flex-1 min-w-0">
               <div className="font-medium truncate">{module.name}</div>
-              <div className={`text-xs truncate ${'text-muted-foreground'}`}>{module.description}</div>
+              <div className={`text-xs truncate ${
+                module.active 
+                  ? 'text-primary-foreground/70' 
+                  : 'text-muted-foreground'
+              }`}>
+                {module.description}
+              </div>
             </div>
             {module.badge && (
-              <span className={`text-xs px-2 py-1 rounded-md font-medium ${'bg-primary text-primary-foreground'}`}>{module.badge}</span>
+              <span className={`text-xs px-2 py-1 rounded-md font-medium ${
+                module.active 
+                  ? 'bg-primary-foreground/20 text-primary-foreground' 
+                  : 'bg-primary text-primary-foreground'
+              }`}>
+                {module.badge}
+              </span>
             )}
-          </NavLink>
+          </button>
         ))}
       </div>
-
+      
+      {/* Settings */}
       <div className="p-4 border-t border-border">
         <button className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-all duration-200">
           <Settings className="w-5 h-5" />
           <span className="font-medium">Settings</span>
         </button>
+        
         <div className="mt-4 bg-card border border-border rounded-xl p-3 shadow-sm">
           <div className="flex items-center gap-2 mb-2">
             <div className="w-2.5 h-2.5 rounded-full bg-success animate-pulse"></div>
             <span className="text-sm font-medium text-card-foreground">System Status</span>
           </div>
+          
           <div className="space-y-1 text-xs">
             <div className="flex justify-between">
               <span className="text-card-foreground/70">Uptime</span>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,69 +1,20 @@
-
 import { Shield, Target, Map, Bell, TrendingUp, Users, Settings, Zap, Database } from 'lucide-react';
+import { NavLink } from 'react-router-dom';
 
 const Navigation = () => {
   const modules = [
-    { 
-      name: "Command Center", 
-      icon: Shield, 
-      active: true, 
-      badge: null,
-      description: "Intelligence dashboard"
-    },
-    { 
-      name: "Ad Signal Hijack", 
-      icon: Zap, 
-      active: false, 
-      badge: "34",
-      description: "Competitor ad tracking"
-    },
-    { 
-      name: "Lead Locator", 
-      icon: Users, 
-      active: false, 
-      badge: "156",
-      description: "Prospect identification"
-    },
-    { 
-      name: "Dominance Map", 
-      icon: Map, 
-      active: false, 
-      badge: null,
-      description: "Territory analysis"
-    },
-    { 
-      name: "Task Generator", 
-      icon: Target, 
-      active: false, 
-      badge: null,
-      description: "Action recommendations"
-    },
-    { 
-      name: "Change Alerts", 
-      icon: Bell, 
-      active: false, 
-      badge: "3",
-      description: "Real-time monitoring"
-    },
-    { 
-      name: "Campaign Manager", 
-      icon: TrendingUp, 
-      active: false, 
-      badge: null,
-      description: "Campaign automation"
-    },
-    { 
-      name: "Competitive CRM", 
-      icon: Database, 
-      active: false, 
-      badge: null,
-      description: "Lead management"
-    }
+    { name: "Command Center", icon: Shield, path: "/", badge: null, description: "Intelligence dashboard" },
+    { name: "Ad Signal Hijack", icon: Zap, path: "/ad-signal-hijack", badge: "34", description: "Competitor ad tracking" },
+    { name: "Lead Locator", icon: Users, path: "/lead-locator", badge: "156", description: "Prospect identification" },
+    { name: "Dominance Map", icon: Map, path: "/dominance-map", badge: null, description: "Territory analysis" },
+    { name: "Task Generator", icon: Target, path: "/task-generator", badge: null, description: "Action recommendations" },
+    { name: "Change Alerts", icon: Bell, path: "/change-alerts", badge: "3", description: "Real-time monitoring" },
+    { name: "Campaign Manager", icon: TrendingUp, path: "/campaign-manager", badge: null, description: "Campaign automation" },
+    { name: "Competitive CRM", icon: Database, path: "/crm", badge: null, description: "Lead management" },
   ];
 
   return (
     <div className="w-72 h-screen bg-background-secondary border-r border-border flex flex-col">
-      {/* Header */}
       <div className="p-6 border-b border-border">
         <div className="flex items-center gap-3 mb-4">
           <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
@@ -74,7 +25,6 @@ const Navigation = () => {
             <p className="text-xs text-muted-foreground">Intelligence Platform</p>
           </div>
         </div>
-        
         <div className="bg-card border border-border rounded-xl p-3 shadow-sm">
           <div className="flex items-center justify-between text-sm">
             <span className="text-card-foreground/70">Active Targets</span>
@@ -82,61 +32,36 @@ const Navigation = () => {
           </div>
         </div>
       </div>
-      
-      {/* Navigation */}
+
       <div className="flex-1 p-4 space-y-2">
         <div className="mb-4">
-          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-            Intelligence Modules
-          </h2>
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">Intelligence Modules</h2>
         </div>
-        
+
         {modules.map((module, index) => (
-          <button
-            key={index}
-            className={`w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200 ${
-              module.active 
-                ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm' 
-                : 'text-foreground hover:bg-accent hover:text-accent-foreground'
-            }`}
-          >
+          <NavLink key={index} to={module.path} className={({ isActive }) => `w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200 ${isActive ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm' : 'text-foreground hover:bg-accent hover:text-accent-foreground'}`}>
             <module.icon className="w-5 h-5 flex-shrink-0" />
             <div className="flex-1 min-w-0">
               <div className="font-medium truncate">{module.name}</div>
-              <div className={`text-xs truncate ${
-                module.active 
-                  ? 'text-primary-foreground/70' 
-                  : 'text-muted-foreground'
-              }`}>
-                {module.description}
-              </div>
+              <div className={`text-xs truncate ${'text-muted-foreground'}`}>{module.description}</div>
             </div>
             {module.badge && (
-              <span className={`text-xs px-2 py-1 rounded-md font-medium ${
-                module.active 
-                  ? 'bg-primary-foreground/20 text-primary-foreground' 
-                  : 'bg-primary text-primary-foreground'
-              }`}>
-                {module.badge}
-              </span>
+              <span className={`text-xs px-2 py-1 rounded-md font-medium ${'bg-primary text-primary-foreground'}`}>{module.badge}</span>
             )}
-          </button>
+          </NavLink>
         ))}
       </div>
-      
-      {/* Settings */}
+
       <div className="p-4 border-t border-border">
         <button className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-all duration-200">
           <Settings className="w-5 h-5" />
           <span className="font-medium">Settings</span>
         </button>
-        
         <div className="mt-4 bg-card border border-border rounded-xl p-3 shadow-sm">
           <div className="flex items-center gap-2 mb-2">
             <div className="w-2.5 h-2.5 rounded-full bg-success animate-pulse"></div>
             <span className="text-sm font-medium text-card-foreground">System Status</span>
           </div>
-          
           <div className="space-y-1 text-xs">
             <div className="flex justify-between">
               <span className="text-card-foreground/70">Uptime</span>

--- a/src/components/ad-signal-hijack/AdCard.tsx
+++ b/src/components/ad-signal-hijack/AdCard.tsx
@@ -1,0 +1,28 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { AdItem } from "@/services/adSignal";
+
+export default function AdCard({ ad }: { ad: AdItem }) {
+  return (
+    <Card className="p-4">
+      <CardContent className="p-0">
+        <div className="flex gap-4">
+          {ad.creative_url ? (
+            <img src={ad.creative_url} alt={ad.headline || "ad"} className="w-40 h-24 object-cover rounded" loading="lazy" />
+          ) : (
+            <div className="w-40 h-24 bg-muted rounded" />
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <Badge variant="secondary">{ad.platform.toUpperCase()}</Badge>
+              {ad.active && <Badge className="bg-success/10 text-success">Active</Badge>}
+              {ad.first_seen && <span className="text-xs text-muted-foreground">Launched {new Date(ad.first_seen).toLocaleDateString()}</span>}
+            </div>
+            <div className="text-sm font-semibold text-foreground truncate">{ad.headline || ad.primary_text || ad.competitor_name}</div>
+            {ad.primary_text && <div className="text-xs text-muted-foreground line-clamp-2">{ad.primary_text}</div>}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ad-signal-hijack/AnalyticsDashboard.tsx
+++ b/src/components/ad-signal-hijack/AnalyticsDashboard.tsx
@@ -1,0 +1,17 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { ChartContainer, ChartLegend, ChartLegendContent } from "@/components/ui/chart";
+
+export default function AnalyticsDashboard() {
+  return (
+    <Card className="saas-card p-6">
+      <CardContent>
+        <h3 className="text-xl font-semibold mb-4">Ad Analysis Dashboard</h3>
+        <ChartContainer config={{}}>
+          {/* Charts will be added after backend integration */}
+          <div className="flex items-center justify-center text-muted-foreground">Charts coming soon</div>
+        </ChartContainer>
+        <ChartLegend content={<ChartLegendContent />} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ad-signal-hijack/AnalyticsDashboard.tsx
+++ b/src/components/ad-signal-hijack/AnalyticsDashboard.tsx
@@ -1,16 +1,40 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { ChartContainer, ChartLegend, ChartLegendContent } from "@/components/ui/chart";
+import { ChartContainer } from "@/components/ui/chart";
+import { useQuery } from "@tanstack/react-query";
+import { SearchFilters } from "@/services/adSignal";
 
-export default function AnalyticsDashboard() {
+export default function AnalyticsDashboard({ filters }: { filters: SearchFilters }) {
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ["ad-analytics", filters],
+    queryFn: async () => {
+      const res = await fetch("/functions/v1/ad-signal-analytics", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ filters }) });
+      if (!res.ok) throw new Error("Failed to fetch analytics");
+      return res.json() as Promise<{ angles: { emotional: number; logical: number }; offers: Record<string, number>; formats: Record<string, number>; trends: Array<{ date: string; count: number }>; }>;
+    },
+  });
+
   return (
     <Card className="saas-card p-6">
       <CardContent>
         <h3 className="text-xl font-semibold mb-4">Ad Analysis Dashboard</h3>
-        <ChartContainer config={{}}>
-          {/* Charts will be added after backend integration */}
-          <div className="flex items-center justify-center text-muted-foreground">Charts coming soon</div>
-        </ChartContainer>
-        <ChartLegend content={<ChartLegendContent />} />
+        {isFetching && <div className="text-sm text-muted-foreground">Loading analytics…</div>}
+        {isError && <div className="text-sm text-destructive">Failed to load analytics</div>}
+        {data && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <ChartContainer config={{}}>
+              <div className="text-sm">Angles: Emotional {data.angles.emotional}, Logical {data.angles.logical}</div>
+            </ChartContainer>
+            <ChartContainer config={{}}>
+              <div className="text-sm">Formats: {Object.entries(data.formats).map(([k,v]) => `${k}:${v}`).join(", ") || '—'}</div>
+            </ChartContainer>
+            <ChartContainer config={{}}>
+              <div className="text-sm">Offers: {Object.entries(data.offers).map(([k,v]) => `${k}:${v}`).join(", ") || '—'}</div>
+            </ChartContainer>
+            <ChartContainer config={{}}>
+              <div className="text-sm">Trend points: {data.trends.length}</div>
+            </ChartContainer>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/ad-signal-hijack/ExportControls.tsx
+++ b/src/components/ad-signal-hijack/ExportControls.tsx
@@ -1,0 +1,18 @@
+import { Button } from "@/components/ui/button";
+import { SearchFilters, exportCSV } from "@/services/adSignal";
+
+export default function ExportControls({ filters }: { filters: SearchFilters }) {
+  return (
+    <div className="flex gap-3">
+      <Button onClick={async () => {
+        const { url, filename } = await exportCSV(filters);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename || 'ads.csv';
+        a.click();
+        URL.revokeObjectURL(url);
+      }}>CSV</Button>
+      <Button variant="outline" disabled>PDF</Button>
+    </div>
+  );
+}

--- a/src/components/ad-signal-hijack/FilterBar.tsx
+++ b/src/components/ad-signal-hijack/FilterBar.tsx
@@ -1,0 +1,30 @@
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { SearchFilters } from "@/services/adSignal";
+
+export default function FilterBar({ onChange }: { onChange: (f: SearchFilters) => void }) {
+  const [business, setBusiness] = useState("");
+  const [industry, setIndustry] = useState("");
+  const [location, setLocation] = useState("");
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center py-4">
+      <Input placeholder="Business name" value={business} onChange={(e) => setBusiness(e.target.value)} />
+      <Input placeholder="Industry" value={industry} onChange={(e) => setIndustry(e.target.value)} />
+      <Input placeholder="Location (city/state/zip)" value={location} onChange={(e) => setLocation(e.target.value)} />
+      <Button variant="outline" onClick={() => onChange({ business, industry, location: parseLocation(location) })}>
+        Apply
+      </Button>
+    </div>
+  );
+}
+
+function parseLocation(input: string) {
+  // naive parser: "city, state zip" or any part
+  const parts = input.split(",");
+  const city = parts[0]?.trim() || undefined;
+  const rest = parts[1]?.trim() || "";
+  const [state, zip] = rest.split(/\s+/);
+  return { city, state, zip };
+}

--- a/src/components/ad-signal-hijack/LiveFeed.tsx
+++ b/src/components/ad-signal-hijack/LiveFeed.tsx
@@ -7,13 +7,17 @@ export default function LiveFeed({ ads, onLoadMore, loading }: { ads: AdItem[]; 
 
   useEffect(() => {
     const el = sentinel.current;
-    if (!el) return;
+    if (!el || ads.length === 0) return; // don't start IO until we have initial results
     const io = new IntersectionObserver((entries) => {
       if (entries[0].isIntersecting && !loading) onLoadMore();
     }, { rootMargin: "800px" });
     io.observe(el);
     return () => io.disconnect();
-  }, [loading, onLoadMore]);
+  }, [loading, onLoadMore, ads.length]);
+
+  if (loading && ads.length === 0) {
+    return <div className="text-sm text-muted-foreground">Loading ads…</div>;
+  }
 
   return (
     <div className="space-y-4">

--- a/src/components/ad-signal-hijack/LiveFeed.tsx
+++ b/src/components/ad-signal-hijack/LiveFeed.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+import { AdItem } from "@/services/adSignal";
+import AdCard from "./AdCard";
+
+export default function LiveFeed({ ads, onLoadMore, loading }: { ads: AdItem[]; onLoadMore: () => void; loading: boolean }) {
+  const sentinel = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el) return;
+    const io = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !loading) onLoadMore();
+    }, { rootMargin: "800px" });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [loading, onLoadMore]);
+
+  return (
+    <div className="space-y-4">
+      {ads.map((ad) => (
+        <AdCard key={ad.id} ad={ad} />
+      ))}
+      <div ref={sentinel} />
+    </div>
+  );
+}

--- a/src/components/ad-signal-hijack/index.ts
+++ b/src/components/ad-signal-hijack/index.ts
@@ -1,0 +1,5 @@
+export { default as FilterBar } from "./FilterBar";
+export { default as LiveFeed } from "./LiveFeed";
+export { default as AdCard } from "./AdCard";
+export { default as AnalyticsDashboard } from "./AnalyticsDashboard";
+export { default as ExportControls } from "./ExportControls";

--- a/src/pages/AdSignalHijack.tsx
+++ b/src/pages/AdSignalHijack.tsx
@@ -4,7 +4,8 @@ import { Zap } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { fetchLiveAds, SearchFilters, AdItem } from "@/services/adSignal";
-import { FilterBar, LiveFeed, AnalyticsDashboard, ExportControls } from "@/components/ad-signal-hijack";
+import { FilterBar, LiveFeed, ExportControls } from "@/components/ad-signal-hijack";
+import AnalyticsDashboard from "@/components/ad-signal-hijack/AnalyticsDashboard";
 
 export default function AdSignalHijack() {
   const [filters, setFilters] = useState<SearchFilters>({ platforms: ["meta"] });
@@ -76,7 +77,7 @@ export default function AdSignalHijack() {
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
               <div className="lg:col-span-2 space-y-6">
-                <AnalyticsDashboard />
+                <AnalyticsDashboard filters={filters} />
               </div>
               <div>
                 <Card className="saas-card p-6">

--- a/src/pages/AdSignalHijack.tsx
+++ b/src/pages/AdSignalHijack.tsx
@@ -1,0 +1,69 @@
+import Navigation from "@/components/Navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Zap } from "lucide-react";
+
+export default function AdSignalHijack() {
+  return (
+    <div className="min-h-screen bg-background flex">
+      <Navigation />
+      <div className="flex-1 overflow-auto">
+        <div className="p-8">
+          <div className="mb-8 sticky top-0 bg-background z-10 border-b border-border">
+            <div className="py-4">
+              <h1 className="text-3xl font-bold text-foreground">Ad Signal Hijack</h1>
+              <p className="text-muted-foreground">Real-time competitor ad tracking & decoding</p>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center py-4">
+              <Input placeholder="Business name" />
+              <Input placeholder="Industry" />
+              <Input placeholder="Location (city/state/zip)" />
+              <Button variant="outline">Filters</Button>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <Card className="saas-card p-6">
+              <CardContent>
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-3">
+                    <Zap className="w-6 h-6 text-primary" />
+                    <h2 className="text-xl font-semibold">Live Ad Feed</h2>
+                  </div>
+                  <div className="flex items-center gap-2 px-3 py-1 bg-success/10 rounded-full">
+                    <div className="w-2 h-2 rounded-full bg-success animate-pulse" />
+                    <span className="text-xs font-medium text-success">LIVE</span>
+                  </div>
+                </div>
+                <div className="text-sm text-muted-foreground">Coming next: real ads loaded here.</div>
+              </CardContent>
+            </Card>
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              <div className="lg:col-span-2 space-y-6">
+                <Card className="saas-card p-6">
+                  <CardContent>
+                    <h3 className="text-xl font-semibold mb-4">Ad Analysis Dashboard</h3>
+                    <div>Charts and insights will render here.</div>
+                  </CardContent>
+                </Card>
+              </div>
+              <div>
+                <Card className="saas-card p-6">
+                  <CardContent>
+                    <h3 className="text-xl font-semibold mb-4">Export & Reporting</h3>
+                    <div className="flex gap-3">
+                      <Button>CSV</Button>
+                      <Button variant="outline">PDF</Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/services/adSignal.ts
+++ b/src/services/adSignal.ts
@@ -28,18 +28,23 @@ export type AdItem = {
   metrics?: Record<string, number>;
 };
 
-export async function fetchLiveAds(filters: SearchFilters, cursor?: string) {
-  const { data, error } = await supabase.functions.invoke("ad-signal-search", {
-    body: { filters, cursor },
+function withTimeout<T>(p: Promise<T>, ms = 5000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`Request timed out after ${ms}ms`)), ms);
+    p.then((v) => { clearTimeout(t); resolve(v); }).catch((e) => { clearTimeout(t); reject(e); });
   });
+}
+
+export async function fetchLiveAds(filters: SearchFilters, cursor?: string) {
+  const promise = supabase.functions.invoke("ad-signal-search", { body: { filters, cursor } });
+  const { data, error } = await withTimeout(promise, 5000);
   if (error) throw error;
   return data as { ads: AdItem[]; nextCursor?: string; total?: number };
 }
 
 export async function fetchAnalytics(filters: SearchFilters) {
-  const { data, error } = await supabase.functions.invoke("ad-signal-analytics", {
-    body: { filters },
-  });
+  const promise = supabase.functions.invoke("ad-signal-analytics", { body: { filters } });
+  const { data, error } = await withTimeout(promise, 5000);
   if (error) throw error;
   return data as {
     angles: { emotional: number; logical: number };
@@ -50,11 +55,9 @@ export async function fetchAnalytics(filters: SearchFilters) {
 }
 
 export async function exportCSV(filters: SearchFilters) {
-  const { data, error } = await supabase.functions.invoke("ad-signal-export", {
-    body: { filters, type: "csv" },
-  });
+  const promise = supabase.functions.invoke("ad-signal-export", { body: { filters, type: "csv" } });
+  const { data, error } = await withTimeout(promise, 8000);
   if (error) throw error;
-  // data: { filename: string, mime: string, base64: string }
   const { filename, mime, base64 } = data as { filename: string; mime: string; base64: string };
   const blob = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
   const url = URL.createObjectURL(new Blob([blob], { type: mime }));

--- a/src/services/adSignal.ts
+++ b/src/services/adSignal.ts
@@ -1,0 +1,62 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type Platform = "meta" | "google" | "youtube" | "tiktok";
+
+export type SearchFilters = {
+  business?: string;
+  industry?: string;
+  location?: { city?: string; state?: string; zip?: string };
+  platforms?: Platform[];
+  dateRange?: { from?: string; to?: string };
+  adFormats?: string[];
+  spendRange?: { min?: number; max?: number };
+  engagementRange?: { min?: number; max?: number };
+};
+
+export type AdItem = {
+  id: string;
+  platform: Platform;
+  competitor_name: string;
+  creative_url?: string;
+  creative_type?: "image" | "video" | "carousel" | string;
+  headline?: string;
+  primary_text?: string;
+  cta?: string;
+  first_seen?: string;
+  last_seen?: string;
+  active?: boolean;
+  metrics?: Record<string, number>;
+};
+
+export async function fetchLiveAds(filters: SearchFilters, cursor?: string) {
+  const { data, error } = await supabase.functions.invoke("ad-signal-search", {
+    body: { filters, cursor },
+  });
+  if (error) throw error;
+  return data as { ads: AdItem[]; nextCursor?: string; total?: number };
+}
+
+export async function fetchAnalytics(filters: SearchFilters) {
+  const { data, error } = await supabase.functions.invoke("ad-signal-analytics", {
+    body: { filters },
+  });
+  if (error) throw error;
+  return data as {
+    angles: { emotional: number; logical: number };
+    offers: Record<string, number>;
+    formats: Record<string, number>;
+    trends: Array<{ date: string; count: number }>;
+  };
+}
+
+export async function exportCSV(filters: SearchFilters) {
+  const { data, error } = await supabase.functions.invoke("ad-signal-export", {
+    body: { filters, type: "csv" },
+  });
+  if (error) throw error;
+  // data: { filename: string, mime: string, base64: string }
+  const { filename, mime, base64 } = data as { filename: string; mime: string; base64: string };
+  const blob = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  const url = URL.createObjectURL(new Blob([blob], { type: mime }));
+  return { url, filename };
+}

--- a/supabase/functions/_shared/meta.ts
+++ b/supabase/functions/_shared/meta.ts
@@ -1,0 +1,40 @@
+// supabase/functions/_shared/meta.ts
+import { AdItem, SearchFilters } from "./types.ts";
+
+const META_BASE = "https://graph.facebook.com/v18.0";
+
+export async function fetchMetaAds(filters: SearchFilters, cursor?: string) {
+  const token = Deno.env.get("META_ADS_ACCESS_TOKEN");
+  if (!token) {
+    return { ads: [], nextCursor: undefined, total: 0 };
+  }
+  // This is a placeholder; Meta Ad Library queries vary by country and params.
+  // Use Ad Library endpoint with proper fields and paging.
+  const url = new URL(`${META_BASE}/ads_archive`);
+  url.searchParams.set("access_token", token);
+  url.searchParams.set("ad_type", "POLITICAL_AND_ISSUE_ADS"); // placeholder to pass validation
+  url.searchParams.set("search_terms", filters.business || "");
+  if (cursor) url.searchParams.set("after", cursor);
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    return { ads: [], nextCursor: undefined, total: 0 };
+  }
+  const json = await res.json();
+  const normalized: AdItem[] = (json.data || []).map((it: any) => ({
+    id: String(it.id),
+    platform: "meta",
+    competitor_name: it.page_name || "Unknown",
+    creative_url: it.ad_snapshot_url,
+    creative_type: "image",
+    headline: it.ad_creative_bodies?.[0] || undefined,
+    primary_text: it.ad_creative_bodies?.[0] || undefined,
+    cta: undefined,
+    first_seen: it.start_time,
+    last_seen: it.stop_time,
+    active: !it.is_inactive,
+    metrics: {},
+    raw_source: it,
+  }));
+  const nextCursor = json.paging?.cursors?.after;
+  return { ads: normalized, nextCursor, total: normalized.length };
+}

--- a/supabase/functions/_shared/types.ts
+++ b/supabase/functions/_shared/types.ts
@@ -1,0 +1,27 @@
+// supabase/functions/_shared/types.ts
+export type Platform = "meta" | "google" | "youtube" | "tiktok";
+export type SearchFilters = {
+  business?: string;
+  industry?: string;
+  location?: { city?: string; state?: string; zip?: string };
+  platforms?: Platform[];
+  dateRange?: { from?: string; to?: string };
+  adFormats?: string[];
+  spendRange?: { min?: number; max?: number };
+  engagementRange?: { min?: number; max?: number };
+};
+export type AdItem = {
+  id: string;
+  platform: Platform;
+  competitor_name: string;
+  creative_url?: string;
+  creative_type?: string;
+  headline?: string;
+  primary_text?: string;
+  cta?: string;
+  first_seen?: string;
+  last_seen?: string;
+  active?: boolean;
+  metrics?: Record<string, number>;
+  raw_source?: unknown;
+};

--- a/supabase/functions/ad-signal-analytics/index.ts
+++ b/supabase/functions/ad-signal-analytics/index.ts
@@ -1,0 +1,14 @@
+// supabase/functions/ad-signal-analytics/index.ts
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+serve(async (req) => {
+  const { filters } = await req.json().catch(() => ({ filters: {} }));
+  // TODO: compute analytics from DB/cache
+  const data = {
+    angles: { emotional: 0, logical: 0 },
+    offers: {},
+    formats: {},
+    trends: [],
+  };
+  return new Response(JSON.stringify(data), { headers: { "content-type": "application/json" } });
+});

--- a/supabase/functions/ad-signal-analytics/index.ts
+++ b/supabase/functions/ad-signal-analytics/index.ts
@@ -1,14 +1,69 @@
 // supabase/functions/ad-signal-analytics/index.ts
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { fetchMetaAds } from "../_shared/meta.ts";
+import type { SearchFilters, AdItem } from "../_shared/types.ts";
+
+function json(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), { ...init, headers: { "content-type": "application/json", ...(init.headers || {}) } });
+}
+
+const EMOTIONAL = ["love", "amazing", "incredible", "fear", "urgent", "excited", "secret", "shock", "wow", "best ever", "insane"];
+const LOGICAL = ["save", "because", "evidence", "data", "proven", "results", "optimize", "tutorial", "guide", "how to", "framework"];
+const OFFERS: Record<string, string[]> = {
+  discount: ["% off", "off", "save", "discount", "sale", "price drop"],
+  free_trial: ["free trial", "try free", "trial"],
+  guarantee: ["guarantee", "money back", "refund"],
+  limited_time: ["limited", "ends soon", "today only", "last chance"],
+  free_shipping: ["free shipping", "ship free"],
+};
+
+function includesAny(text: string, keywords: string[]) {
+  const t = text.toLowerCase();
+  return keywords.some((k) => t.includes(k));
+}
+
+function analyzeAds(ads: AdItem[]) {
+  let emotional = 0, logical = 0;
+  const offers: Record<string, number> = {};
+  const formats: Record<string, number> = {};
+  const trendsMap: Record<string, number> = {};
+
+  for (const ad of ads) {
+    const text = `${ad.headline || ""} ${ad.primary_text || ""}`.trim();
+    if (text) {
+      if (includesAny(text, EMOTIONAL)) emotional++;
+      if (includesAny(text, LOGICAL)) logical++;
+      for (const [offer, keys] of Object.entries(OFFERS)) {
+        if (includesAny(text, keys)) offers[offer] = (offers[offer] || 0) + 1;
+      }
+    }
+    const fmt = (ad.creative_type || "unknown").toLowerCase();
+    formats[fmt] = (formats[fmt] || 0) + 1;
+    if (ad.first_seen) {
+      const d = new Date(ad.first_seen);
+      const day = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())).toISOString().slice(0, 10);
+      trendsMap[day] = (trendsMap[day] || 0) + 1;
+    }
+  }
+
+  const trends = Object.entries(trendsMap).sort(([a],[b]) => a < b ? -1 : 1).map(([date, count]) => ({ date, count }));
+  return { angles: { emotional, logical }, offers, formats, trends };
+}
 
 serve(async (req) => {
-  const { filters } = await req.json().catch(() => ({ filters: {} }));
-  // TODO: compute analytics from DB/cache
-  const data = {
-    angles: { emotional: 0, logical: 0 },
-    offers: {},
-    formats: {},
-    trends: [],
-  };
-  return new Response(JSON.stringify(data), { headers: { "content-type": "application/json" } });
+  const { filters = {} }: { filters?: SearchFilters } = await req.json().catch(() => ({} as any));
+  const platforms = (filters.platforms || ["meta"]).filter(Boolean);
+  let ads: AdItem[] = [];
+
+  try {
+    if (platforms.includes("meta")) {
+      const meta = await fetchMetaAds(filters);
+      ads = ads.concat(meta.ads);
+    }
+  } catch (e) {
+    console.error("analytics meta error", e);
+  }
+
+  const result = analyzeAds(ads);
+  return json(result);
 });

--- a/supabase/functions/ad-signal-export/index.ts
+++ b/supabase/functions/ad-signal-export/index.ts
@@ -1,0 +1,17 @@
+// supabase/functions/ad-signal-export/index.ts
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+function toBase64(u8: Uint8Array) {
+  let s = "";
+  u8.forEach((b) => (s += String.fromCharCode(b)));
+  return btoa(s);
+}
+
+serve(async (req) => {
+  const { filters, type } = await req.json().catch(() => ({ filters: {}, type: "csv" }));
+  if (type === "csv") {
+    const csv = new TextEncoder().encode("id,platform,competitor,headline\n");
+    return new Response(JSON.stringify({ filename: "ads.csv", mime: "text/csv", base64: toBase64(csv) }), { headers: { "content-type": "application/json" } });
+  }
+  return new Response(JSON.stringify({ error: "PDF export not yet implemented" }), { status: 400, headers: { "content-type": "application/json" } });
+});

--- a/supabase/functions/ad-signal-search/index.ts
+++ b/supabase/functions/ad-signal-search/index.ts
@@ -1,9 +1,30 @@
 // supabase/functions/ad-signal-search/index.ts
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { fetchMetaAds } from "../_shared/meta.ts";
+import type { SearchFilters } from "../_shared/types.ts";
+
+function json(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), { ...init, headers: { "content-type": "application/json", ...(init.headers || {}) } });
+}
 
 serve(async (req) => {
-  const { filters, cursor } = await req.json().catch(() => ({ filters: {}, cursor: undefined }));
-  // TODO: integrate Meta Ads Library API here using secure env vars
-  // For now return empty result with nextCursor undefined
-  return new Response(JSON.stringify({ ads: [], nextCursor: undefined, total: 0 }), { headers: { "content-type": "application/json" } });
+  const { filters = {}, cursor }: { filters?: SearchFilters; cursor?: string } = await req.json().catch(() => ({} as any));
+
+  const platforms = (filters.platforms || ["meta"]).filter(Boolean);
+  const results = [] as Array<{ ads: any[]; nextCursor?: string; total?: number }>;
+
+  try {
+    if (platforms.includes("meta")) {
+      const meta = await fetchMetaAds(filters, cursor);
+      results.push(meta);
+    }
+  } catch (e) {
+    console.error("meta error", e);
+  }
+
+  const ads = results.flatMap((r) => r.ads);
+  const nextCursor = results.find((r) => r.nextCursor)?.nextCursor;
+  const total = results.reduce((acc, r) => acc + (r.total || 0), 0);
+
+  return json({ ads, nextCursor, total });
 });

--- a/supabase/functions/ad-signal-search/index.ts
+++ b/supabase/functions/ad-signal-search/index.ts
@@ -1,0 +1,9 @@
+// supabase/functions/ad-signal-search/index.ts
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+serve(async (req) => {
+  const { filters, cursor } = await req.json().catch(() => ({ filters: {}, cursor: undefined }));
+  // TODO: integrate Meta Ads Library API here using secure env vars
+  // For now return empty result with nextCursor undefined
+  return new Response(JSON.stringify({ ads: [], nextCursor: undefined, total: 0 }), { headers: { "content-type": "application/json" } });
+});

--- a/supabase/migrations/2025-08-08_ad_signal_schema.sql
+++ b/supabase/migrations/2025-08-08_ad_signal_schema.sql
@@ -1,0 +1,49 @@
+-- 20250808_ad_signal_schema.sql
+create table if not exists competitors (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  website text,
+  industry text,
+  locations jsonb default '[]'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists ads (
+  id uuid primary key default gen_random_uuid(),
+  platform text not null,
+  competitor_id uuid references competitors(id) on delete set null,
+  creative_url text,
+  creative_type text,
+  headline text,
+  primary_text text,
+  cta text,
+  first_seen timestamptz,
+  last_seen timestamptz,
+  active boolean default false,
+  metrics jsonb,
+  raw_source jsonb,
+  created_at timestamptz default now()
+);
+
+create index if not exists ads_platform_idx on ads(platform);
+create index if not exists ads_competitor_idx on ads(competitor_id);
+create index if not exists ads_first_seen_idx on ads(first_seen);
+create index if not exists ads_last_seen_idx on ads(last_seen);
+create index if not exists ads_active_idx on ads(active);
+
+create table if not exists searches (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid,
+  filters jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists exports (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid,
+  filters jsonb not null,
+  type text not null,
+  status text default 'completed',
+  file_url text,
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
- Add /ad-signal-hijack route (React Router)
- Scaffold Ad Signal Hijack page with header, sticky filter bar, live feed, analytics and export sections
- Update left navigation to link to routes with active styling
- Add client service layer (Supabase functions)
- Add UI components: FilterBar, LiveFeed, AdCard, AnalyticsDashboard, ExportControls
- Add Supabase Edge Function stubs: ad-signal-search, ad-signal-analytics, ad-signal-export
- Add initial SQL schema for competitors/ads/searches/exports

Next steps (follow-up PRs):
- Implement Meta Ads Library provider within ad-signal-search (secure env)
- Compute analytics from DB with cache & aggregations
- CSV/PDF export finish; shareable links
- Tests (unit/integration/UI) and docs